### PR TITLE
Add GitHub release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,9 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: pipx run tox -e publish
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- publish release artifacts to GitHub when a tag is pushed

## Testing
- `pipx run pre-commit run --files .github/workflows/ci.yml`
- `pip install -e .[testing]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846acdb4420832b9230a3a4dfaba93f