### PR TITLE
Update metadata import and Python requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-# python_requires = >=3.8
+python_requires = >=3.8
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in

--- a/src/ffbb_api_client/__init__.py
+++ b/src/ffbb_api_client/__init__.py
@@ -1,6 +1,6 @@
 import base64
 import json
-import sys
+from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 from typing import List
 
 from requests.exceptions import ConnectionError, ReadTimeout
@@ -59,8 +59,6 @@ default_cached_session = CachedSession(
     allowable_methods=("GET", "POST"),
     key_fn=create_cache_key,
 )
-
-from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/src/ffbb_api_client/__init__.py
+++ b/src/ffbb_api_client/__init__.py
@@ -60,11 +60,7 @@ default_cached_session = CachedSession(
     key_fn=create_cache_key,
 )
 
-if sys.version_info[:2] >= (3, 8):
-    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
-    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
-else:
-    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
 try:
     # Change here if project is renamed and does not equal the package name


### PR DESCRIPTION
## Summary
- require Python >=3.8 in `setup.cfg`
- drop version check and TODO comment for metadata import

## Testing
- `pip install --break-system-packages -e .[testing]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b974a6f4832b805bc1b699e5d9a4