### PR TITLE
Add docstrings to dataclass models

### DIFF
--- a/src/ffbb_api_client/models/agenda_and_results.py
+++ b/src/ffbb_api_client/models/agenda_and_results.py
@@ -1,3 +1,5 @@
+"""Model for AgendaAndResults returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -10,6 +12,18 @@ from .standing import Standing
 
 @dataclass
 class AgendaAndResults:
+    """
+    Data class for AgendaAndResults information.
+
+    Attributes:
+        sub_competitions: Value from the API.
+        groups: Value from the API.
+        days: Value from the API.
+        current_day: Value from the API.
+        matchs: Value from the API.
+        standings: Value from the API.
+    """
+
     sub_competitions: Optional[List[Group]] = None
     groups: Optional[List[Group]] = None
     days: Optional[List[Day]] = None
@@ -19,6 +33,7 @@ class AgendaAndResults:
 
     @staticmethod
     def from_dict(obj: Any) -> "AgendaAndResults":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         sub_competitions = from_union(
             [lambda x: from_list(Group.from_dict, x), from_none],
@@ -43,6 +58,7 @@ class AgendaAndResults:
         )
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.sub_competitions is not None:
             result["subCompetitions"] = from_union(

--- a/src/ffbb_api_client/models/area.py
+++ b/src/ffbb_api_client/models/area.py
@@ -1,3 +1,5 @@
+"""Model for Area returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -6,17 +8,27 @@ from ..utils.converters import from_list, from_none, from_str, from_union, to_cl
 
 @dataclass
 class Area:
+    """
+    Data class for Area information.
+
+    Attributes:
+        id: Value from the API.
+        name: Value from the API.
+    """
+
     id: Optional[str] = None
     name: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "Area":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         id = from_union([from_str, from_none], obj.get("id"))
         name = from_union([from_str, from_none], obj.get("name"))
         return Area(id, name)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.id is not None:
             result["id"] = from_union([from_str, from_none], self.id)

--- a/src/ffbb_api_client/models/basketball_court.py
+++ b/src/ffbb_api_client/models/basketball_court.py
@@ -1,3 +1,5 @@
+"""Model for BasketballCourt returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -6,12 +8,22 @@ from ..utils.converters import from_int, from_none, from_str, from_union
 
 @dataclass
 class BasketballCourt:
+    """
+    Data class for BasketballCourt information.
+
+    Attributes:
+        number: Value from the API.
+        id: Value from the API.
+        label: Value from the API.
+    """
+
     number: Optional[None]
     id: Optional[int] = None
     label: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "BasketballCourt":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         numero = from_none(obj.get("numero"))
         id = from_union([from_int, from_none], obj.get("id"))
@@ -19,6 +31,7 @@ class BasketballCourt:
         return BasketballCourt(numero, id, libelle)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.number is not None:
             result["numero"] = from_none(self.number)

--- a/src/ffbb_api_client/models/category.py
+++ b/src/ffbb_api_client/models/category.py
@@ -1,5 +1,4 @@
-"""
-Basketball category classification for FFBB competitions.
+"""Basketball category classification for FFBB competitions.
 
 This module defines the Category enum which represents different age and skill
 categories used in French basketball competitions, from youth categories (U7-U20)

--- a/src/ffbb_api_client/models/championship.py
+++ b/src/ffbb_api_client/models/championship.py
@@ -1,3 +1,5 @@
+"""Model for Championship returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -6,12 +8,22 @@ from ..utils.converters import from_list, from_none, from_str, from_union, to_cl
 
 @dataclass
 class Championship:
+    """
+    Data class for Championship information.
+
+    Attributes:
+        name: Value from the API.
+        id: Value from the API.
+        type: Value from the API.
+    """
+
     name: Optional[str] = None
     id: Optional[str] = None
     type: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "Championship":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         name = from_union([from_str, from_none], obj.get("name"))
         id = from_union([from_str, from_none], obj.get("id"))
@@ -19,6 +31,7 @@ class Championship:
         return Championship(name, id, type)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.name is not None:
             result["name"] = from_union([from_str, from_none], self.name)

--- a/src/ffbb_api_client/models/club_details.py
+++ b/src/ffbb_api_client/models/club_details.py
@@ -1,5 +1,4 @@
-"""
-Club details data model for FFBB API responses.
+"""Club details data model for FFBB API responses.
 
 This module contains the ClubDetails dataclass which represents detailed
 information about a basketball club, including its facilities, teams, and
@@ -80,6 +79,7 @@ class ClubDetails:
         return ClubDetails(infos, fields, teams)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.infos is not None:
             result["infos"] = from_union(

--- a/src/ffbb_api_client/models/club_infos.py
+++ b/src/ffbb_api_client/models/club_infos.py
@@ -1,3 +1,5 @@
+"""Model for ClubInfos returned by the FFBB API."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, List, Optional

--- a/src/ffbb_api_client/models/competition.py
+++ b/src/ffbb_api_client/models/competition.py
@@ -1,3 +1,5 @@
+"""Model for Competition returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -6,12 +8,22 @@ from ..utils.converters import from_list, from_none, from_str, from_union, to_cl
 
 @dataclass
 class Competition:
+    """
+    Data class for Competition information.
+
+    Attributes:
+        name: Value from the API.
+        id: Value from the API.
+        group_field: Value from the API.
+    """
+
     name: Optional[str] = None
     id: Optional[str] = None
     group_field: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "Competition":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         name = from_union([from_str, from_none], obj.get("name"))
         id = from_union([from_str, from_none], obj.get("id"))
@@ -19,6 +31,7 @@ class Competition:
         return Competition(name, id, group_field)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.name is not None:
             result["name"] = from_union([from_str, from_none], self.name)

--- a/src/ffbb_api_client/models/day.py
+++ b/src/ffbb_api_client/models/day.py
@@ -1,3 +1,5 @@
+"""Model for Day returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -6,17 +8,27 @@ from ..utils.converters import from_int, from_none, from_union
 
 @dataclass
 class Day:
+    """
+    Data class for Day information.
+
+    Attributes:
+        name: Value from the API.
+        desc: Value from the API.
+    """
+
     name: Optional[int] = None
     desc: Optional[int] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "Day":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         name = from_union([from_int, from_none], obj.get("name"))
         desc = from_union([from_int, from_none], obj.get("desc"))
         return Day(name, desc)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.name is not None:
             result["name"] = from_union([from_int, from_none], self.name)

--- a/src/ffbb_api_client/models/default.py
+++ b/src/ffbb_api_client/models/default.py
@@ -1,3 +1,5 @@
+"""Model for Default returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 

--- a/src/ffbb_api_client/models/field.py
+++ b/src/ffbb_api_client/models/field.py
@@ -1,3 +1,5 @@
+"""Model for Field returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 

--- a/src/ffbb_api_client/models/geo_location.py
+++ b/src/ffbb_api_client/models/geo_location.py
@@ -1,3 +1,5 @@
+"""Model for GeoLocation returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -13,6 +15,18 @@ from ..utils.converters import (
 
 @dataclass
 class GeoLocation:
+    """
+    Data class for GeoLocation information.
+
+    Attributes:
+        postal_code: Value from the API.
+        latitude: Value from the API.
+        longitude: Value from the API.
+        title: Value from the API.
+        adress: Value from the API.
+        city: Value from the API.
+    """
+
     postal_code: Optional[int] = None
     latitude: Optional[float] = None
     longitude: Optional[float] = None
@@ -22,6 +36,7 @@ class GeoLocation:
 
     @staticmethod
     def from_dict(obj: Any) -> "GeoLocation":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         postal_code = from_union(
             [from_none, lambda x: int(from_str(x))], obj.get("codePostal")
@@ -34,6 +49,7 @@ class GeoLocation:
         return GeoLocation(postal_code, latitude, longitude, title, adress, city)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.postal_code is not None:
             result["codePostal"] = from_union(

--- a/src/ffbb_api_client/models/group.py
+++ b/src/ffbb_api_client/models/group.py
@@ -1,3 +1,5 @@
+"""Model for Group returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -7,12 +9,22 @@ from .competition_type import CompetitionType, extract_competition_type
 
 @dataclass
 class Group:
+    """
+    Data class for Group information.
+
+    Attributes:
+        id: Value from the API.
+        name: Value from the API.
+        competition_type: Value from the API.
+    """
+
     id: Optional[str] = None
     name: Optional[str] = None
     competition_type: Optional[CompetitionType] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "Group":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         id = from_union([from_str, from_none], obj.get("id"))
         name = from_union([from_str, from_none], obj.get("name"))
@@ -22,6 +34,7 @@ class Group:
         return Group(id, name, competition_type)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.id is not None:
             result["id"] = from_union([from_str, from_none], self.id)

--- a/src/ffbb_api_client/models/history.py
+++ b/src/ffbb_api_client/models/history.py
@@ -1,3 +1,5 @@
+"""Model for History returned by the FFBB API."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
@@ -9,6 +11,18 @@ from .type_association import TypeAssociation
 
 @dataclass
 class History:
+    """
+    Data class for History information.
+
+    Attributes:
+        cessation: Value from the API.
+        affiliation_date: Value from the API.
+        reaffiliation_date: Value from the API.
+        season: Value from the API.
+        creation_date: Value from the API.
+        association_type: Value from the API.
+    """
+
     cessation: None
     affiliation_date: Optional[datetime] = None
     reaffiliation_date: Optional[datetime] = None
@@ -18,6 +32,7 @@ class History:
 
     @staticmethod
     def from_dict(obj: Any) -> "History":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         cessation = from_union([from_datetime, from_none], obj.get("cessation"))
         affiliation_date = from_union(
@@ -41,6 +56,7 @@ class History:
         )
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.cessation is not None:
             result["cessation"] = from_none(self.cessation)

--- a/src/ffbb_api_client/models/item.py
+++ b/src/ffbb_api_client/models/item.py
@@ -1,3 +1,5 @@
+"""Model for Item returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -7,17 +9,27 @@ from .snippet import Snippet
 
 @dataclass
 class Item:
+    """
+    Data class for Item information.
+
+    Attributes:
+        id: Value from the API.
+        snippet: Value from the API.
+    """
+
     id: Optional[str] = None
     snippet: Optional[Snippet] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "Item":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         id = from_union([from_str, from_none], obj.get("id"))
         snippet = from_union([Snippet.from_dict, from_none], obj.get("snippet"))
         return Item(id, snippet)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.id is not None:
             result["id"] = from_union([from_str, from_none], self.id)

--- a/src/ffbb_api_client/models/league.py
+++ b/src/ffbb_api_client/models/league.py
@@ -1,3 +1,5 @@
+"""Model for League returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -6,17 +8,27 @@ from ..utils.converters import from_list, from_none, from_str, from_union, to_cl
 
 @dataclass
 class League:
+    """
+    Data class for League information.
+
+    Attributes:
+        id: Value from the API.
+        name: Value from the API.
+    """
+
     id: Optional[str] = None
     name: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "League":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         id = from_union([from_str, from_none], obj.get("id"))
         name = from_union([from_str, from_none], obj.get("name"))
         return League(id, name)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.id is not None:
             result["id"] = from_union([from_str, from_none], self.id)

--- a/src/ffbb_api_client/models/match.py
+++ b/src/ffbb_api_client/models/match.py
@@ -1,3 +1,5 @@
+"""Model for Match returned by the FFBB API."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
@@ -8,6 +10,21 @@ from .score import Score
 
 @dataclass
 class Match:
+    """
+    Data class for Match information.
+
+    Attributes:
+        formatted_date: Value from the API.
+        time: Value from the API.
+        hometeam: Value from the API.
+        visitorteam: Value from the API.
+        score: Value from the API.
+        date: Value from the API.
+        remise: Value from the API.
+        round: Value from the API.
+        match_id: Value from the API.
+    """
+
     formatted_date: Optional[datetime] = None
     time: Optional[str] = None
     hometeam: Optional[str] = None
@@ -20,6 +37,7 @@ class Match:
 
     @staticmethod
     def from_dict(obj: Any) -> "Match":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         formatted_date_str = from_union([from_int, from_none], obj.get("formattedDate"))
         formatted_date = (
@@ -63,6 +81,7 @@ class Match:
         )
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.formatted_date is not None:
             result["formattedDate"] = int(self.formatted_date.timestamp())

--- a/src/ffbb_api_client/models/match_detail.py
+++ b/src/ffbb_api_client/models/match_detail.py
@@ -1,3 +1,5 @@
+"""Model for MatchDetail returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -6,12 +8,22 @@ from ..utils.converters import from_list, from_none, from_str, from_union, to_cl
 
 @dataclass
 class MatchDetail:
+    """
+    Data class for MatchDetail information.
+
+    Attributes:
+        category: Value from the API.
+        title: Value from the API.
+        desc: Value from the API.
+    """
+
     category: Optional[str] = None
     title: Optional[str] = None
     desc: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "MatchDetail":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         category = from_union([from_str, from_none], obj.get("category"))
         title = from_union([from_str, from_none], obj.get("title"))
@@ -19,6 +31,7 @@ class MatchDetail:
         return MatchDetail(category, title, desc)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.category is not None:
             result["category"] = from_union([from_str, from_none], self.category)

--- a/src/ffbb_api_client/models/member.py
+++ b/src/ffbb_api_client/models/member.py
@@ -1,3 +1,5 @@
+"""Model for Member returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -13,6 +15,26 @@ from ..utils.converters import (
 
 @dataclass
 class Member:
+    """
+    Data class for Member information.
+
+    Attributes:
+        id: Value from the API.
+        last_name: Value from the API.
+        first_name: Value from the API.
+        address_line1: Value from the API.
+        address_line2: Value from the API.
+        postal_code: Value from the API.
+        city: Value from the API.
+        email: Value from the API.
+        landline_phone: Value from the API.
+        mobile_phone: Value from the API.
+        role_code: Value from the API.
+        role_label: Value from the API.
+        license_id: Value from the API.
+        consent_to_website_publishing: Value from the API.
+    """
+
     id: Optional[int] = None
     last_name: Optional[str] = None
     first_name: Optional[str] = None
@@ -30,6 +52,7 @@ class Member:
 
     @staticmethod
     def from_dict(obj: Any) -> "Member":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         address_line2 = from_union([from_str, from_none], obj.get("adresse2"))
         postal_code = from_union(
@@ -67,6 +90,7 @@ class Member:
         )
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.address_line2 is not None:
             result["adresse2"] = from_union(

--- a/src/ffbb_api_client/models/municipality.py
+++ b/src/ffbb_api_client/models/municipality.py
@@ -1,3 +1,5 @@
+"""Model for Municipality returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -14,6 +16,19 @@ from ..utils.converters import (
 
 @dataclass
 class Municipality:
+    """
+    Data class for Municipality information.
+
+    Attributes:
+        postal_code: Value from the API.
+        insee_code: Value from the API.
+        postal_community_code: Value from the API.
+        id: Value from the API.
+        label: Value from the API.
+        municipality_id: Value from the API.
+        municipality_label: Value from the API.
+    """
+
     postal_code: Optional[int] = None
     insee_code: Optional[str] = None
     postal_community_code: Optional[int] = None
@@ -24,6 +39,7 @@ class Municipality:
 
     @staticmethod
     def from_dict(obj: Any) -> "Municipality":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         postal_code = from_union(
             [from_none, lambda x: int(from_str(x))], obj.get("codePostal")
@@ -49,6 +65,7 @@ class Municipality:
         )
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.postal_code is not None:
             result["codePostal"] = from_union(

--- a/src/ffbb_api_client/models/news.py
+++ b/src/ffbb_api_client/models/news.py
@@ -1,3 +1,5 @@
+"""Model for News returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -13,6 +15,20 @@ from ..utils.converters import (
 
 @dataclass
 class News:
+    """
+    Data class for News information.
+
+    Attributes:
+        id: Value from the API.
+        date: Value from the API.
+        url: Value from the API.
+        author: Value from the API.
+        category: Value from the API.
+        title: Value from the API.
+        image: Value from the API.
+        excerpt: Value from the API.
+    """
+
     id: Optional[int] = None
     date: Optional[str] = None
     url: Optional[str] = None
@@ -24,6 +40,7 @@ class News:
 
     @staticmethod
     def from_dict(obj: Any) -> "News":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         id = from_union([from_none, lambda x: int(from_str(x))], obj.get("id"))
         date = from_union([from_str, from_none], obj.get("date"))
@@ -36,6 +53,7 @@ class News:
         return News(id, date, url, author, category, title, image, excerpt)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.id is not None:
             result["id"] = from_union(

--- a/src/ffbb_api_client/models/page_info.py
+++ b/src/ffbb_api_client/models/page_info.py
@@ -1,3 +1,5 @@
+"""Model for PageInfo returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 

--- a/src/ffbb_api_client/models/practice_offers.py
+++ b/src/ffbb_api_client/models/practice_offers.py
@@ -1,3 +1,5 @@
+"""Model for PracticeOffers returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 

--- a/src/ffbb_api_client/models/resource_id.py
+++ b/src/ffbb_api_client/models/resource_id.py
@@ -1,3 +1,5 @@
+"""Model for ResourceID returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -6,17 +8,27 @@ from ..utils.converters import from_none, from_str, from_union
 
 @dataclass
 class ResourceID:
+    """
+    Data class for ResourceID information.
+
+    Attributes:
+        kind: Value from the API.
+        video_id: Value from the API.
+    """
+
     kind: Optional[str] = None
     video_id: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "ResourceID":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         kind = from_union([from_str, from_none], obj.get("kind"))
         video_id = from_union([from_str, from_none], obj.get("videoId"))
         return ResourceID(kind, video_id)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.kind is not None:
             result["kind"] = from_union([from_str, from_none], self.kind)

--- a/src/ffbb_api_client/models/score.py
+++ b/src/ffbb_api_client/models/score.py
@@ -1,8 +1,18 @@
+"""Model for Score returned by the FFBB API."""
+
 from dataclasses import dataclass
 
 
 @dataclass
 class Score:
+    """
+    Data class for Score information.
+
+    Attributes:
+        home: Value from the API.
+        visitor: Value from the API.
+    """
+
     home: int
     visitor: int
 

--- a/src/ffbb_api_client/models/season.py
+++ b/src/ffbb_api_client/models/season.py
@@ -1,3 +1,5 @@
+"""Model for Season returned by the FFBB API."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
@@ -15,6 +17,18 @@ from ..utils.converters import (
 
 @dataclass
 class Season:
+    """
+    Data class for Season information.
+
+    Attributes:
+        active: Value from the API.
+        id: Value from the API.
+        code: Value from the API.
+        label: Value from the API.
+        start_date: Value from the API.
+        end_date: Value from the API.
+    """
+
     active: Optional[bool] = None
     id: Optional[int] = None
     code: Optional[str] = None
@@ -24,6 +38,7 @@ class Season:
 
     @staticmethod
     def from_dict(obj: Any) -> "Season":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         active = from_union(
             [from_none, lambda x: from_stringified_bool(from_str(x))], obj.get("actif")
@@ -36,6 +51,7 @@ class Season:
         return Season(active, id, code, label, start_date, end_date)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.active is not None:
             result["actif"] = from_union(

--- a/src/ffbb_api_client/models/snippet.py
+++ b/src/ffbb_api_client/models/snippet.py
@@ -1,3 +1,5 @@
+"""Model for Snippet returned by the FFBB API."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
@@ -16,6 +18,23 @@ from .thumbnails import Thumbnails
 
 @dataclass
 class Snippet:
+    """
+    Data class for Snippet information.
+
+    Attributes:
+        published_at: Value from the API.
+        channel_id: Value from the API.
+        title: Value from the API.
+        description: Value from the API.
+        thumbnails: Value from the API.
+        channel_title: Value from the API.
+        playlist_id: Value from the API.
+        position: Value from the API.
+        resource_id: Value from the API.
+        video_owner_channel_title: Value from the API.
+        video_owner_channel_id: Value from the API.
+    """
+
     published_at: Optional[datetime] = None
     channel_id: Optional[str] = None
     title: Optional[str] = None
@@ -30,6 +49,7 @@ class Snippet:
 
     @staticmethod
     def from_dict(obj: Any) -> "Snippet":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         published_at = from_union([from_datetime, from_none], obj.get("publishedAt"))
         channel_id = from_union([from_str, from_none], obj.get("channelId"))
@@ -65,6 +85,7 @@ class Snippet:
         )
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.published_at is not None:
             result["publishedAt"] = from_union(

--- a/src/ffbb_api_client/models/standing.py
+++ b/src/ffbb_api_client/models/standing.py
@@ -1,3 +1,5 @@
+"""Model for Standing returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional, Union
 
@@ -13,6 +15,28 @@ from ..utils.converters import (
 
 @dataclass
 class Standing:
+    """
+    Data class for Standing information.
+
+    Attributes:
+        pos: Value from the API.
+        points: Value from the API.
+        day: Value from the API.
+        win: Value from the API.
+        lost: Value from the API.
+        draw: Value from the API.
+        penalties: Value from the API.
+        forfeited: Value from the API.
+        defaults: Value from the API.
+        arb: Value from the API.
+        ent: Value from the API.
+        scored: Value from the API.
+        conceded: Value from the API.
+        quotient: Value from the API.
+        club: Value from the API.
+        initi: Value from the API.
+    """
+
     pos: Optional[Union[int, str]] = None
     points: Optional[Union[int, str]] = None
     day: Optional[Union[int, str]] = None
@@ -32,6 +56,7 @@ class Standing:
 
     @staticmethod
     def from_dict(obj: Any) -> "Standing":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         pos = from_union([from_int, from_str, from_none], obj.get("pos"))
         points = from_union([from_int, from_str, from_none], obj.get("points"))
@@ -69,6 +94,7 @@ class Standing:
         )
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.pos is not None:
             result["pos"] = from_union([from_int, from_str, from_none], self.pos)

--- a/src/ffbb_api_client/models/team.py
+++ b/src/ffbb_api_client/models/team.py
@@ -1,3 +1,5 @@
+"""Model for Team returned by the FFBB API."""
+
 import re
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -53,6 +55,24 @@ def extract_phase_number(input_str: str) -> int:
 
 @dataclass
 class Team:
+    """
+    Data class for Team information.
+
+    Attributes:
+        id: Value from the API.
+        sub_competition: Value from the API.
+        name: Value from the API.
+        group: Value from the API.
+        category: Value from the API.
+        group_field: Value from the API.
+        competition_type: Value from the API.
+        sex: Value from the API.
+        geographical_zone: Value from the API.
+        division_number: Value from the API.
+        pool_letter: Value from the API.
+        phase_number: Value from the API.
+    """
+
     id: Optional[str] = None
     sub_competition: Optional[str] = None
     name: Optional[str] = None
@@ -68,6 +88,7 @@ class Team:
 
     @staticmethod
     def from_dict(obj: Any) -> "Team":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         id = from_union([from_str, from_none], obj.get("id"))
         sub_competition = from_union([from_str, from_none], obj.get("subCompetition"))
@@ -97,6 +118,7 @@ class Team:
         )
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.id is not None:
             result["id"] = from_union([from_str, from_none], self.id)

--- a/src/ffbb_api_client/models/thumbnails.py
+++ b/src/ffbb_api_client/models/thumbnails.py
@@ -1,3 +1,5 @@
+"""Model for Thumbnails returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -7,6 +9,17 @@ from .default import Default
 
 @dataclass
 class Thumbnails:
+    """
+    Data class for Thumbnails information.
+
+    Attributes:
+        default: Value from the API.
+        medium: Value from the API.
+        high: Value from the API.
+        standard: Value from the API.
+        maxres: Value from the API.
+    """
+
     default: Optional[Default] = None
     medium: Optional[Default] = None
     high: Optional[Default] = None
@@ -15,6 +28,7 @@ class Thumbnails:
 
     @staticmethod
     def from_dict(obj: Any) -> "Thumbnails":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         default = from_union([Default.from_dict, from_none], obj.get("default"))
         medium = from_union([Default.from_dict, from_none], obj.get("medium"))
@@ -24,6 +38,7 @@ class Thumbnails:
         return Thumbnails(default, medium, high, standard, maxres)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.default is not None:
             result["default"] = from_union(

--- a/src/ffbb_api_client/models/type_association.py
+++ b/src/ffbb_api_client/models/type_association.py
@@ -1,3 +1,5 @@
+"""Model for TypeAssociation returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -6,12 +8,22 @@ from ..utils.converters import from_int, from_none, from_str, from_union
 
 @dataclass
 class TypeAssociation:
+    """
+    Data class for TypeAssociation information.
+
+    Attributes:
+        id: Value from the API.
+        libelle: Value from the API.
+        code: Value from the API.
+    """
+
     id: Optional[int] = None
     libelle: Optional[str] = None
     code: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "TypeAssociation":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         id = from_union([from_int, from_none], obj.get("id"))
         libelle = from_union([from_str, from_none], obj.get("libelle"))
@@ -19,6 +31,7 @@ class TypeAssociation:
         return TypeAssociation(id, libelle, code)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.id is not None:
             result["id"] = from_union([from_int, from_none], self.id)

--- a/src/ffbb_api_client/models/videos.py
+++ b/src/ffbb_api_client/models/videos.py
@@ -1,3 +1,5 @@
+"""Model for Videos returned by the FFBB API."""
+
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -8,12 +10,22 @@ from .page_info import PageInfo
 
 @dataclass
 class Videos:
+    """
+    Data class for Videos information.
+
+    Attributes:
+        next_page_token: Value from the API.
+        items: Value from the API.
+        page_info: Value from the API.
+    """
+
     next_page_token: Optional[str] = None
     items: Optional[List[Item]] = None
     page_info: Optional[PageInfo] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "Videos":
+        """Create an instance from a dictionary."""
         assert isinstance(obj, dict)
         next_page_token = from_union([from_str, from_none], obj.get("nextPageToken"))
         items = from_union(
@@ -23,6 +35,7 @@ class Videos:
         return Videos(next_page_token, items, page_info)
 
     def to_dict(self) -> dict:
+        """Convert the instance to a dictionary."""
         result: dict = {}
         if self.next_page_token is not None:
             result["nextPageToken"] = from_union(


### PR DESCRIPTION
## Summary
- document all dataclass modules with module, class, `from_dict` and `to_dict` docstrings
- run formatting

## Testing
- `./run_tests.sh` *(fails: environment variables FFBB_BASIC_AUTH_USER and FFBB_BASIC_AUTH_PASS are not set)*
- `python run_tests.py` *(fails to run tests because tox and pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684816aa90fc832bb253f7240d03ce4d